### PR TITLE
Update setup URLS for PaperSpigot and Waterfall

### DIFF
--- a/cloudnet-lib/src/main/java/de/dytanic/cloudnet/lib/server/version/ProxyVersion.java
+++ b/cloudnet-lib/src/main/java/de/dytanic/cloudnet/lib/server/version/ProxyVersion.java
@@ -25,7 +25,7 @@ public enum ProxyVersion {
             case HEXACORD:
                 return new MultiValue<>("https://yivesmirror.com/files/hexacord/HexaCord-v180.jar", "HexaCord.jar");
             case WATERFALL:
-                return new MultiValue<>("https://yivesmirror.com/files/waterfall/Waterfall-160.jar", "Waterfall.jar");
+                return new MultiValue<>("https://ci.destroystokyo.com/job/Waterfall/lastSuccessfulBuild/artifact/Waterfall-Proxy/bootstrap/target/Waterfall.jar", "Waterfall.jar");
             default:
                 return new MultiValue<>("https://ci.md-5.net/job/BungeeCord/lastSuccessfulBuild/artifact/bootstrap/target/BungeeCord.jar", "BungeeCord.jar");
         }

--- a/cloudnet-wrapper/src/main/java/de/dytanic/cloudnetwrapper/setup/SetupSpigotVersion.java
+++ b/cloudnet-wrapper/src/main/java/de/dytanic/cloudnetwrapper/setup/SetupSpigotVersion.java
@@ -153,7 +153,7 @@ public class SetupSpigotVersion
                     }
                 }
             case "paper":
-                System.out.println("Choose a PaperSpigot version [\"1.8.8\", \"1.11.2\", \"1.12.2\"]");
+                System.out.println("Choose a PaperSpigot version [\"1.8.8\", \"1.9.4\", \"1.10.2\", \"1.11.2\", \"1.12.2\"]");
                 while (true)
                 {
                     try
@@ -161,13 +161,19 @@ public class SetupSpigotVersion
                         switch (cancer == null ? reader.readLine().toLowerCase() : cancer)
                         {
                             case "1.8.8":
-                                download.run("https://yivesmirror.com/files/paperspigot/PaperSpigot-1.8.8-R0.1-SNAPSHOT-latest.jar");
+                                download.run("https://ci.destroystokyo.com/job/PaperSpigot/443/artifact/paperclip-1.8.8-fix.jar");
+                                return;
+                            case "1.9.4":
+                                download.run("https://ci.destroystokyo.com/job/PaperSpigot/773/artifact/paperclip-773.jar");
+                                return;
+                            case "1.10.2":
+                                download.run("https://ci.destroystokyo.com/job/PaperSpigot/916/artifact/paperclip-916.2.jar");
                                 return;
                             case "1.11.2":
-                                download.run("https://yivesmirror.com/files/paperspigot/PaperSpigot-1.11.2-b1104.jar");
+                                download.run("https://ci.destroystokyo.com/job/PaperSpigot/1104/artifact/paperclip-1104.jar");
                                 return;
                             case "1.12.2":
-                                download.run("https://yivesmirror.com/files/paperspigot/PaperSpigot-1.12.2-b1293.jar");
+                                download.run("https://ci.destroystokyo.com/job/PaperSpigot/lastSuccessfulBuild/artifact/paperclip.jar");
                                 break;
                             default:
                                 System.out.println("This version is not supported!");


### PR DESCRIPTION
Added versions 1.9.4 and 1.10.2 to PaperSpigot setup, and changed Waterfall to use official URLS.